### PR TITLE
Delete stock routing fix resolves #7

### DIFF
--- a/quotes/views.py
+++ b/quotes/views.py
@@ -54,7 +54,7 @@ def delete(request, stock_id):
 	item = Stock.objects.get(pk=stock_id)
 	item.delete()
 	messages.success(request, ("Stock Has Been Deleted!"))
-	return redirect(delete_stock)
+	return redirect(portfolio)
 
 
 

--- a/quotes/views.py
+++ b/quotes/views.py
@@ -51,9 +51,12 @@ def portfolio(request):
 
 
 def delete(request, stock_id):
-	item = Stock.objects.get(pk=stock_id)
-	item.delete()
-	messages.success(request, ("Stock Has Been Deleted!"))
+	try:
+		item = Stock.objects.get(pk=stock_id)
+		item.delete()
+		messages.success(request, ("Stock Has Been Deleted!"))
+	except Stock.DoesNotExist:
+		messages.error(request, "Can't find stock!")
 	return redirect(portfolio)
 
 


### PR DESCRIPTION
I went ahead and added a fix to `issue-7`.

There's no need to redirect to delete_stock if you need to redirect to portfolio, the message will appear in portfolio now too once deleted.

I also went ahead and added validation if trying to delete a stock that doesn't exist and added appropriate message.